### PR TITLE
Upgrade python, as current version is deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,18 +3,16 @@ FROM node:10
 # AWS CLI needs the PYTHONIOENCODING environment varialbe to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8
 
-RUN apt-get update && apt-get install -y \
-    python3-pip python3-setuptools \
-    --no-install-recommends \
-    && python3 -m pip install --upgrade --force-reinstall pip
-
-RUN pip3 install awscli
+# Install AWS CLI
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+RUN unzip awscliv2.zip
+RUN ./aws/install
 
 ## Install Serverless
 WORKDIR /app
 RUN npm -g install serverless@1
 
-RUN apt-get install -y locales locales-all
+RUN apt-get update && apt-get install -y locales locales-all
 ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8


### PR DESCRIPTION
Fixes #2 

Current version: aws-cli/2.0.50 Python/3.7.3
Updated following AWS guide: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html
Image on docker hub is already updated and tested in a deployment task of one of our serverless apps.